### PR TITLE
Added BloonModel.GetTotalCash

### DIFF
--- a/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
+++ b/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
@@ -13,6 +13,44 @@ namespace BTD_Mod_Helper.Extensions
 {
     public static class BloonModelExt
     {
+        private static readonly System.Collections.Generic.IDictionary<string, int> cash = new System.Collections.Generic.Dictionary<string, int>
+                {
+                    {"Red", 1},
+                    {"Blue", 2},
+                    {"Green", 3},
+                    {"Yellow", 4},
+                    {"Pink", 5},
+                    {"Purple", 11},
+                    {"White", 11},
+                    {"Black", 11},
+                    {"Zebra", 23},
+                    {"Lead", 23},
+                    {"Rainbow", 47},
+                    {"Ceramic", 95},
+                    {"Moab", 381},
+                    {"Bfb", 1525},
+                    {"Zomg", 6101},
+                    {"Ddt", 381},
+                    {"Bad", 13346}
+                };
+        
+        /// <summary>
+        /// (Cross-Game compatable) Return how much cash this bloon would give if popped completely
+        /// </summary>
+        public static int GetTotalCash(this BloonModel bloonModel)
+        {
+            if (!cash.TryGetValue(bloonModel.GetBaseID(), out int bloonCash))
+            {
+                bloonCash = 1;
+                foreach (BloonModel child in bloonModel.GetChildBloonModels(InGame.instance?.GetSimulation()))
+                {
+                    bloonCash += child.GetTotalCash();
+                }
+            }
+
+            return bloonCash;
+        }
+        
         /// <summary>
         /// (Cross-Game compatible) Return the number position of this bloon from the list of all bloons (Game.instance.model.bloons)
         /// </summary>

--- a/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
+++ b/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
@@ -42,8 +42,7 @@ namespace BTD_Mod_Helper.Extensions
         {
             if (layersPopped == 0) return 0;
 
-            int bloonCash = 1;
-            if (layersPopped > -1 && !cash.TryGetValue(bloonModel.GetBaseID(), out bloonCash))
+            if (layersPopped >= 0 || !cash.TryGetValue(bloonModel.GetBaseID(), out int bloonCash))
             {
                 bloonCash = 1;
                 foreach (BloonModel child in bloonModel.GetChildBloonModels(InGame.instance?.GetSimulation()))

--- a/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
+++ b/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
@@ -13,26 +13,7 @@ namespace BTD_Mod_Helper.Extensions
 {
     public static class BloonModelExt
     {
-        private static readonly System.Collections.Generic.IDictionary<string, int> cash = new System.Collections.Generic.Dictionary<string, int>
-                {
-                    {"Red", 1},
-                    {"Blue", 2},
-                    {"Green", 3},
-                    {"Yellow", 4},
-                    {"Pink", 5},
-                    {"Purple", 11},
-                    {"White", 11},
-                    {"Black", 11},
-                    {"Zebra", 23},
-                    {"Lead", 23},
-                    {"Rainbow", 47},
-                    {"Ceramic", 95},
-                    {"Moab", 381},
-                    {"Bfb", 1525},
-                    {"Zomg", 6101},
-                    {"Ddt", 381},
-                    {"Bad", 13346}
-                };
+        public static readonly System.Collections.Generic.IDictionary<string, int> cash = new System.Collections.Generic.Dictionary<string, int>();
         
         /// <summary>
         /// (Cross-Game compatable) Return how much cash this bloon would give if popped by <paramref name="layersPopped"/> number of layers
@@ -49,6 +30,7 @@ namespace BTD_Mod_Helper.Extensions
                 {
                     bloonCash += child.GetTotalCash(layersPopped-1);
                 }
+                cash.Add(bloonModel.GetBaseID(), bloonCash);
             }
 
             return bloonCash;

--- a/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
+++ b/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
@@ -35,16 +35,20 @@ namespace BTD_Mod_Helper.Extensions
                 };
         
         /// <summary>
-        /// (Cross-Game compatable) Return how much cash this bloon would give if popped completely
+        /// (Cross-Game compatable) Return how much cash this bloon would give if popped by <paramref name="layersPopped"/> number of layers
         /// </summary>
-        public static int GetTotalCash(this BloonModel bloonModel)
+        /// <param name="layersPopped">How many layers of bloons to pop, ignoring layer health. If less than 0, calculates for the entire bloon</param>
+        public static int GetTotalCash(this BloonModel bloonModel, int layersPopped = -1)
         {
-            if (!cash.TryGetValue(bloonModel.GetBaseID(), out int bloonCash))
+            if (layersPopped == 0) return 0;
+
+            int bloonCash = 1;
+            if (layersPopped > -1 && !cash.TryGetValue(bloonModel.GetBaseID(), out bloonCash))
             {
                 bloonCash = 1;
                 foreach (BloonModel child in bloonModel.GetChildBloonModels(InGame.instance?.GetSimulation()))
                 {
-                    bloonCash += child.GetTotalCash();
+                    bloonCash += child.GetTotalCash(layersPopped-1);
                 }
             }
 

--- a/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
+++ b/BTD Mod Helper Core/Extensions/ModelExtensions/BloonModelExt.cs
@@ -23,14 +23,15 @@ namespace BTD_Mod_Helper.Extensions
         {
             if (layersPopped == 0) return 0;
 
-            if (layersPopped >= 0 || !cash.TryGetValue(bloonModel.GetBaseID(), out int bloonCash))
+            var children = bloonModel.GetChildBloonModels(InGame.instance?.GetSimulation());
+            if ((layersPopped >= 0) || !cash.TryGetValue(bloonModel.GetBaseID(), out int bloonCash))
             {
                 bloonCash = 1;
-                foreach (BloonModel child in bloonModel.GetChildBloonModels(InGame.instance?.GetSimulation()))
+                foreach (BloonModel child in children)
                 {
-                    bloonCash += child.GetTotalCash(layersPopped-1);
+                    bloonCash += child.GetTotalCash(layersPopped - 1);
                 }
-                cash.Add(bloonModel.GetBaseID(), bloonCash);
+                if (layersPopped < 0) { cash.Add(bloonModel.GetBaseID(), bloonCash); }
             }
 
             return bloonCash;

--- a/BloonsTD6 Mod Helper/Patches/TitleScreen_Start.cs
+++ b/BloonsTD6 Mod Helper/Patches/TitleScreen_Start.cs
@@ -1,4 +1,5 @@
 ﻿using BTD_Mod_Helper.Api;
+using BTD_Mod_Helper.Extensions;
 using HarmonyLib;
 using System.Linq;
 using Assets.Main.Scenes;
@@ -18,6 +19,8 @@ namespace BTD_Mod_Helper.Patches
                 ModContent.LoadAllModContent(mod);
             }
             
+            BloonModelExt.cashValues.Clear();
+
             MelonMain.DoPatchMethods(mod => mod.OnTitleScreen());
         }
     }


### PR DESCRIPTION
Adds a function that will return how much cash a bloon would give if popped completely from either a dictionary if it is a vanilla bloon, or by recursing over the children if it is a modded bloon. I have tested all the different bloons, including my custom one, in sandbox and can confirm that they work with minimal lag (except with a BAD when I was testing without it using the dictionary for vanilla bloons).