### PR TITLE
Bugfix: Handle all custom messages in NKMultiConnection.Receive

### DIFF
--- a/BloonsTD6 Mod Helper/Patches/Player/NKMultiConnection_Receive.cs
+++ b/BloonsTD6 Mod Helper/Patches/Player/NKMultiConnection_Receive.cs
@@ -12,8 +12,9 @@ namespace BTD_Mod_Helper.Patches
             var messageQueue = __instance.ReceiveQueue;
             if (messageQueue == null || messageQueue.Count == 0)
                 return;
-            
-            for (int i = 0; i < messageQueue.Count; i++)
+
+            var messageCount = messageQueue.Count;
+            for (int i = 0; i < messageCount; i++)
             {
                 var message = messageQueue.Dequeue();
                 bool consumed = false;
@@ -28,5 +29,4 @@ namespace BTD_Mod_Helper.Patches
             }
         }
     }
-
 }


### PR DESCRIPTION
Current implementation has an oversight where for each item returning true and not-being requeued, one from the end of the queue will be skipped as 
`messageQueue.Count` will be evaluated on every loop iteration.

This should fix it.