### PR TITLE
Fixed: Messages not delivered in some game states.

### DIFF
--- a/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Update.cs
+++ b/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Update.cs
@@ -6,10 +6,22 @@ namespace BTD_Mod_Helper.Patches
     [HarmonyPatch(typeof(NKMultiGameInterface), nameof(NKMultiGameInterface.Update))]
     internal class NKMultiGameInterface_Update
     {
-        [HarmonyPostfix]
-        internal static void Postfix(ref NKMultiGameInterface __instance)
+        [HarmonyPriority(Priority.HigherThanNormal)]
+        [HarmonyPrefix]
+        internal static void Prefix(ref NKMultiGameInterface __instance)
         {
             SessionData.Instance.NkGI = __instance;
+            if (__instance.relayConnection == null) 
+                return;
+
+            // There exist some game states where send/receive might not be called
+            // on a regular basis, e.g. co-op menu, leading to lost messages.
+
+            // In addition, it seems the game will also clear the receive queue in some
+            // cases. I think it's in this update method, but I (Sewer) have not confirmed this.
+            // In any case, this should help prevent lost messages.  
+            __instance.relayConnection.Receive();
+            __instance.relayConnection.Send();
         }
     }
 }


### PR DESCRIPTION
Assuming mods worked before, I take it the game was updated to clear the receive queue during NKGI's Update function [didn't verify this in IDA].

This should help prevent lost messages.

Note: Please see the comment in the commit for extra details.