### PR TITLE
Added: Useful Networking Related APIs & Functionality to Mod Helper

### DIFF
--- a/BloonsTD6 Mod Helper/Api/Coop/MessageUtils.cs
+++ b/BloonsTD6 Mod Helper/Api/Coop/MessageUtils.cs
@@ -1,42 +1,54 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Text;
+using Newtonsoft.Json;
 using NinjaKiwi.NKMulti;
 using UnhollowerBaseLib;
 
 namespace BTD_Mod_Helper.Api.Coop
 {
+    /// <summary>
+    /// Utility functions used for sending messages over the network.
+    /// </summary>
     public class MessageUtils
     {
-        public static Message CreateMessage<T>(T objectToSend, string code = "") where T : Il2CppSystem.Object
+        /// <summary>
+        /// Creates a message to be sent over the network.
+        /// The message will be serialized as JSON.
+        /// </summary>
+        /// <param name="objectToSend">The object to be sent. The object's properties will be serialized.</param>
+        /// <param name="code">Unique code for your specific message.</param>
+        public static Message CreateMessageEx<T>(T objectToSend, string code = "")
         {
             var json = JsonConvert.SerializeObject(objectToSend);
-            var serialize = Il2CppSystem.Text.Encoding.Default.GetBytes(json);
+            var serialize = Encoding.Default.GetBytes(json);
             code = string.IsNullOrEmpty(code) ? MelonMain.coopMessageCode : code;
             return new Message(code, serialize);
-
-            //throw new System.Exception("This code was broken in BTD6 update 27.0");
-            // commented code below broke in update 27.0
-            //Il2CppStructArray<byte> serialize = SerialisationUtil.Serialise(objectToSend);
-
-            // this code is commented because code above is broken
-            /*code = string.IsNullOrEmpty(code) ? MelonMain.coopMessageCode : code;
-            return new Message(code, serialize);*/
         }
 
+        /// <summary>
+        /// Reads a message sent from the network.
+        /// Assumes message is sent as JSON. (via <see cref="CreateMessageEx{T}"/>)
+        /// </summary>
+        /// <param name="serializedMessage">Raw bytes received from the network.</param>
         public static T ReadMessage<T>(Il2CppStructArray<byte> serializedMessage)
         {
-            var modMessage = Il2CppSystem.Text.Encoding.Default.GetString(serializedMessage);
+            var modMessage = Encoding.Default.GetString(serializedMessage);
             return JsonConvert.DeserializeObject<T>(modMessage);
-
-            //throw new System.Exception("This code was broken in BTD6 update 27.0");
-            // commented code below broke in update 27.0
-            //return SerialisationUtil.Deserialise<T>(serializedMessage);
         }
 
+        /// <summary>
+        /// Reads a message sent from the network.
+        /// Assumes message is sent as JSON. (via <see cref="CreateMessageEx{T}"/>)
+        /// </summary>
+        /// <param name="message">Message received from the network.</param>
         public static T ReadMessage<T>(Message message)
         {
-            //throw new System.Exception("This code was broken in BTD6 update 27.0");
-            // commented code below broke in update 27.0
             return ReadMessage<T>(message.bytes);
         }
+
+        #region Backwards Binary Compatibility
+        [Obsolete($"For backwards compatibility reasons only, please use {nameof(CreateMessageEx)}")]
+        public static Message CreateMessage<T>(T objectToSend, string code = "") where T : Il2CppSystem.Object => CreateMessage(objectToSend, code);
+        #endregion
     }
 }

--- a/BloonsTD6 Mod Helper/BloonsTD6 Mod Helper.csproj
+++ b/BloonsTD6 Mod Helper/BloonsTD6 Mod Helper.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <LangVersion>latest</LangVersion>
+    <!-- I want my nullables goddamn it. -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'BloonsTD6 - Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -19,7 +21,6 @@
     <DefineConstants>BloonsTD6;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>obj\BloonsTD6 - Debug\BloonsTD6 Mod Helper.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -31,7 +32,6 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <DocumentationFile>bin\BloonsTD6 - Release\BloonsTD6 Mod Helper.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -123,6 +123,8 @@
     <Compile Include="Patches\Player\Btd6Player_Save.cs" />
     <Compile Include="Patches\Player\Btd6Player_SaveNow.cs" />
     <Compile Include="Patches\Player\NKMultiConnection_Receive.cs" />
+    <Compile Include="Patches\Player\NKMultiGameInterface_Disconnect.cs" />
+    <Compile Include="Patches\Player\NKMultiGameInterface_Connect.cs" />
     <Compile Include="Patches\Player\NKMultiGameInterface_Update.cs" />
     <Compile Include="Patches\Player\ProfileModel_Validate.cs" />
     <Compile Include="Patches\Projectiles\Projectile_Initialise.cs" />

--- a/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
+++ b/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
@@ -46,6 +46,7 @@ namespace BTD_Mod_Helper
 
         /// <summary>
         /// Executed once the user has connected to a game session.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         /// <param name="nkGi">The interface used to interact with the game.</param>
         public virtual void OnConnected(NKMultiGameInterface nkGi)
@@ -54,6 +55,7 @@ namespace BTD_Mod_Helper
 
         /// <summary>
         /// Executed once the user has tried to connect to a server, but failed to do so.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         /// <param name="nkGi">The interface used to interact with the game.</param>
         public virtual void OnConnectFail(NKMultiGameInterface nkGi)
@@ -62,6 +64,7 @@ namespace BTD_Mod_Helper
 
         /// <summary>
         /// Executed once the player has disconnected from a server.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         /// <param name="nkGi">The interface used to interact with the game.</param>
         public virtual void OnDisconnected(NKMultiGameInterface nkGi)
@@ -70,6 +73,7 @@ namespace BTD_Mod_Helper
 
         /// <summary>
         /// Executed when a new client has joined the game session.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         /// <param name="nkGi">The interface used to interact with the game.</param>
         /// <param name="peerId">Index of the peer in question.</param>
@@ -79,6 +83,7 @@ namespace BTD_Mod_Helper
 
         /// <summary>
         /// Executed when a new client has left the game session.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         /// <param name="nkGi">The interface used to interact with the game.</param>
         /// <param name="peerId">Index of the peer in question.</param>
@@ -93,6 +98,7 @@ namespace BTD_Mod_Helper
         /// <br/>
         /// If this is one of your messages and you're consuming and acting on it, return true.
         /// Otherwise, return false. Seriously.
+        /// Note: Only invoked if <see cref="BloonsMod.CheatMod"/> == true.
         /// </summary>
         public virtual bool ActOnMessage(Message message)
         {

--- a/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
+++ b/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
@@ -21,6 +21,7 @@ using NinjaKiwi.NKMulti;
 using Assets.Scripts.Unity.Display;
 using Assets.Scripts.Simulation.Towers.Behaviors.Attack;
 using Assets.Scripts.Simulation.Towers.Behaviors.Abilities;
+using BTD_Mod_Helper.Api.Coop;
 
 namespace BTD_Mod_Helper
 {
@@ -41,13 +42,54 @@ namespace BTD_Mod_Helper
             Game.instance.model.AddTowerToGame(newTowerModel, towerDetailsModel);
         }
 
+        #region Networking Hooks
 
-        #region Misc Hooks
+        /// <summary>
+        /// Executed once the user has connected to a game session.
+        /// </summary>
+        /// <param name="nkGi">The interface used to interact with the game.</param>
+        public virtual void OnConnected(NKMultiGameInterface nkGi)
+        {
+        }
+
+        /// <summary>
+        /// Executed once the user has tried to connect to a server, but failed to do so.
+        /// </summary>
+        /// <param name="nkGi">The interface used to interact with the game.</param>
+        public virtual void OnConnectFail(NKMultiGameInterface nkGi)
+        {
+        }
+
+        /// <summary>
+        /// Executed once the player has disconnected from a server.
+        /// </summary>
+        /// <param name="nkGi">The interface used to interact with the game.</param>
+        public virtual void OnDisconnected(NKMultiGameInterface nkGi)
+        {
+        }
+
+        /// <summary>
+        /// Executed when a new client has joined the game session.
+        /// </summary>
+        /// <param name="nkGi">The interface used to interact with the game.</param>
+        /// <param name="peerId">Index of the peer in question.</param>
+        public virtual void OnPeerConnected(NKMultiGameInterface nkGi, int peerId)
+        {
+        }
+
+        /// <summary>
+        /// Executed when a new client has left the game session.
+        /// </summary>
+        /// <param name="nkGi">The interface used to interact with the game.</param>
+        /// <param name="peerId">Index of the peer in question.</param>
+        public virtual void OnPeerDisconnected(NKMultiGameInterface nkGi, int peerId)
+        {
+        }
 
         /// <summary>
         /// Acts on a Network message that's been sent to the client
         /// <br/>
-        /// Use Game.instance.GetNKgI().ReadMessage&lt;YOUR_CLASS_NAME&gt;(message) to get back the same object/class you sent.
+        /// Use <see cref="MessageUtils.ReadMessage{T}(Message)"/> to read back the message you sent.
         /// <br/>
         /// If this is one of your messages and you're consuming and acting on it, return true.
         /// Otherwise, return false. Seriously.
@@ -57,6 +99,10 @@ namespace BTD_Mod_Helper
             return false;
         }
 
+        #endregion
+
+
+        #region Misc Hooks
 
         /// <summary>
         /// Called when the player's ProfileModel is loaded.

--- a/BloonsTD6 Mod Helper/Extensions/GameExt.cs
+++ b/BloonsTD6 Mod Helper/Extensions/GameExt.cs
@@ -13,12 +13,27 @@ using NinjaKiwi.Common;
 using NinjaKiwi.NKMulti;
 using NinjaKiwi.Players.Files.SaveStrategies;
 using System.Collections.Generic;
+using Assets.Scripts.Unity.UI_New.Coop;
+using NinjaKiwi.LiNK.Lobbies;
 using UnhollowerBaseLib;
 
 namespace BTD_Mod_Helper.Extensions
 {
     public static partial class GameExt
     {
+        /// <summary>
+        /// Returns the current lobby screen.
+        /// </summary>
+        public static CoopLobbyScreen? GetCoopLobbyScreen(this Game game)
+        {
+            return (game.GetMenuManager()?.currMenu?.Item2?.TryCast<CoopLobbyScreen>());
+        }
+
+        /// <summary>
+        /// Returns the current lobby connection.
+        /// </summary>
+        public static LobbyConnection? GetCoopLobbyConnection(this Game game) => game.GetCoopLobbyScreen()?.lobbyConnection;
+
         /// <summary>
         /// Returns the directory where the Player's Profile.save file is located.
         /// Not set until after reaching the Main Menu for the first time

--- a/BloonsTD6 Mod Helper/Extensions/InGameExt.cs
+++ b/BloonsTD6 Mod Helper/Extensions/InGameExt.cs
@@ -14,6 +14,21 @@ namespace BTD_Mod_Helper.Extensions
     public static partial class InGameExt
     {
         /// <summary>
+        /// Returns true if the initial co-op handshake has finished and user has co-op game details.
+        /// </summary>
+        /// <param name="inGame">The game.</param>
+        public static bool IsCoOpReady(this InGame? inGame)
+        {
+            if (inGame == null)
+                return false;
+
+            if (!inGame.IsCoop)
+                return false;
+
+            return inGame.coopGame != null;
+        }
+
+        /// <summary>
         /// Custom API method that changes the game's round set to a custom RoundSetModel.
         /// </summary>
         /// <param name="roundSet">New Round Set Model to use</param>

--- a/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Connect.cs
+++ b/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Connect.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using HarmonyLib;
+using MelonLoader;
+using NinjaKiwi.NKMulti;
+using Task = Il2CppSystem.Threading.Tasks.Task;
+
+namespace BTD_Mod_Helper.Patches.Player
+{
+    [HarmonyPatch(typeof(NKMultiGameInterface), nameof(NKMultiGameInterface.Connect))]
+    internal class NKMultiGameInterface_Connect
+    {
+        [HarmonyPostfix]
+        public static void Postfix(NKMultiGameInterface __instance, ref Task __result) => __result.ContinueWith(new Action<Task>(task => OnConnectTaskFinished(__instance, task)));
+
+        private static void OnConnectTaskFinished(NKMultiGameInterface instance, Task obj)
+        {
+            if (instance.IsConnected)
+            {
+                MelonMain.PerformHook(mod => { mod.OnConnected(instance); });
+                instance.add_PeerConnectedEvent(new Action<int>((peerId) => OnPeerConnected(instance, peerId)));
+                instance.add_PeerDisconnectedEvent(new Action<int>((peerId) => OnPeerDisconnected(instance, peerId)));
+            }
+            else
+            {
+                MelonMain.PerformHook(mod => { mod.OnConnectFail(instance); });
+            }
+        }
+
+        private static void OnPeerDisconnected(NKMultiGameInterface nkGi, int peerId) => MelonMain.PerformHook(mod => { mod.OnPeerDisconnected(nkGi, peerId); });
+
+        private static void OnPeerConnected(NKMultiGameInterface nkGi, int peerId) => MelonMain.PerformHook(mod => { mod.OnPeerConnected(nkGi, peerId); });
+    }
+}

--- a/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Disconnect.cs
+++ b/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Disconnect.cs
@@ -1,0 +1,12 @@
+﻿using HarmonyLib;
+using NinjaKiwi.NKMulti;
+
+namespace BTD_Mod_Helper.Patches.Player
+{
+    [HarmonyPatch(typeof(NKMultiGameInterface), nameof(NKMultiGameInterface.Disconnect))]
+    public class NKMultiGameInterface_Disconnect
+    {
+        [HarmonyPostfix]
+        public static void Postfix(NKMultiGameInterface __instance) => MelonMain.PerformHook(mod => { mod.OnDisconnected(__instance); });
+    }
+}

--- a/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Update.cs
+++ b/BloonsTD6 Mod Helper/Patches/Player/NKMultiGameInterface_Update.cs
@@ -6,10 +6,22 @@ namespace BTD_Mod_Helper.Patches
     [HarmonyPatch(typeof(NKMultiGameInterface), nameof(NKMultiGameInterface.Update))]
     internal class NKMultiGameInterface_Update
     {
-        [HarmonyPostfix]
-        internal static void Postfix(ref NKMultiGameInterface __instance)
+        [HarmonyPriority(Priority.HigherThanNormal)]
+        [HarmonyPrefix]
+        internal static void Prefix(ref NKMultiGameInterface __instance)
         {
             SessionData.Instance.NkGI = __instance;
+            if (__instance.relayConnection == null) 
+                return;
+
+            // There exist some game states where send/receive might not be called
+            // on a regular basis, e.g. co-op menu, leading to lost messages.
+
+            // In addition, it seems the game will also clear the receive queue in some
+            // cases. I think it's in this update method, but I (Sewer) have not confirmed this.
+            // In any case, this should help prevent lost messages.  
+            __instance.relayConnection.Receive();
+            __instance.relayConnection.Send();
         }
     }
 }


### PR DESCRIPTION
This pull request has the following:

Fixes:
- Fix for lost messages due to game clearing them [same as other PR].
- Removed debug logging code from NKMultiGameInterfaceExt. [apparently left by error]

Api(s):
- `BloonsTD6Mod.OnConnected`: Client has connected to a lobby.
- `BloonsTD6Mod.OnConnectFail`: Client tried to connect but failed to do so.
- `BloonsTD6Mod.OnDisconnected`: Client has disconnected from a lobby.
- `BloonsTD6Mod.OnPeerConnected`: Executed when a new client has joined the game session.
- `BloonsTD6Mod.OnPeerDisconnected`: Executed when a client has disconnected from the game.
-----
- `NKMultiGameInterfaceExt.IsCoOpHost`: Returns if current player is in control of the lobby.
- `NKMultiGameInterfaceExt.SendMessageEx`: Same as `SendMessage`, but not constrained to IL2CPP classes. The constraint should be removed from the original method but I fear of breaking binary compatibility if I do.  
-----
- `MessageUtils.CreateMessageEx`: Same story as with `SendMessageEx`.
-----
- `GameExt.GetCoopLobbyScreen`: Gets the current co-op lobby screen.
- `GameExt.GetCoopLobbyConnection`: Gets the connection details of the current co-op lobby.
- -----
- `InGame.IsCoOpReady`: True if details of a co-op game can be obtained at this time.

Other:
- Added missing documentation in e.g. MessageUtils
- Added `CheatMod` flag warnings for Networking APIs.