### PR TITLE
Remove exceptions with no materials in ModTowerCustomDisplay.

### DIFF
--- a/BloonsTD6 Mod Helper/Patches/Resources/Factory_FindAndSetupPrototypeAsync.cs
+++ b/BloonsTD6 Mod Helper/Patches/Resources/Factory_FindAndSetupPrototypeAsync.cs
@@ -60,12 +60,19 @@ internal class Factory_FindAndSetupPrototypeAsync
                         __instance.PrototypeRoot).AddComponent<UnityDisplayNode>();
                     udn.Active = false;
                     udn.transform.position = new Vector3(-3000, 0);
-                    var material = assetBundle.LoadAsset(customDisplay.MaterialName).Cast<Material>();
-                    udn.genericRenderers[0].SetMaterial(material);
+                    try
+                    {
+                        var material = assetBundle.LoadAsset(customDisplay.MaterialName).Cast<Material>();
+                        udn.genericRenderers[0].SetMaterial(material);
+                    }
+                    catch (Exception e)
+                    {
+                        ModHelper.Error($"Failed to load material for {modDisplay.Name}");
+                        ModHelper.Error(e);
+                    }
                     SetupUDN(udn, modDisplay, onComplete);
                     return false;
                 }
-
                 objectId = modDisplay.BaseDisplay;
                 onComplete = new System.Action<UnityDisplayNode>(node =>
                 {


### PR DESCRIPTION
i had trouble with the materials working without needing the MaterialName string. All i added was a try and except to when custom materials were added