### PR TITLE
Fixes enums in ModHelper settings

### DIFF
--- a/Shared/Api/ModOptions/ModSetting.cs
+++ b/Shared/Api/ModOptions/ModSetting.cs
@@ -110,6 +110,8 @@ public abstract class ModSetting<T> : ModSetting
                 $"Error: ModSetting type mismatch between {typeof(T).Name} and {val.GetType().Name} for {displayName}");
         }
     }
+
+    internal override Type GetSettingType() => typeof(T);
 }
 
 /// <summary>
@@ -187,8 +189,8 @@ public abstract class ModSetting
     {
         
     }
-    
-    
+
+    internal virtual Type GetSettingType() => typeof(object);
 
     /// <summary>
     /// Creates a base ModHelperOption component based on the name, description and icon of this

--- a/Shared/Api/ModOptions/ModSettingEnum.cs
+++ b/Shared/Api/ModOptions/ModSettingEnum.cs
@@ -54,6 +54,7 @@ namespace BTD_Mod_Helper.Api.ModOptions
                 new Action<int>(i => SetValue((T) Enum.GetValues(typeof(T)).GetValue(i)!)),
                 VanillaSprites.BlueInsertPanelRound, 80f
             );
+            dropdown.Dropdown.SetValue(Enum.GetValues(typeof(T)).Cast<T>().ToList().IndexOf(value));
 
 
             option.SetResetAction(new Action(() =>

--- a/Shared/Api/ModOptions/ModSettingsHandler.cs
+++ b/Shared/Api/ModOptions/ModSettingsHandler.cs
@@ -63,22 +63,7 @@ internal static class ModSettingsHandler
                         try
                         {
                             var modSetting = mod.ModSettings[name];
-                            // Iterate until find ModSetting<> base class to get it's type
-                            var settingType = modSetting.GetType();
-                            var foundType = false;
-                            while(!foundType && settingType.BaseType != typeof(ModSetting) && settingType.BaseType != null)
-                            {
-                                settingType = settingType.BaseType;
-                                if (settingType.IsGenericType && settingType.GetGenericTypeDefinition() == typeof(ModSetting<>))
-                                {
-                                    // Load using the type from ModSetting<>
-                                    modSetting.Load(token.ToObject(settingType.GenericTypeArguments[0]));
-                                    foundType = true;
-                                }
-                            }
-                            // Load just from object if failed to find type
-                            if (!foundType)
-                                modSetting.Load(token.ToObject<object>());
+                            modSetting.Load(token.ToObject(modSetting.GetSettingType()));
                         }
                         catch (Exception e)
                         {

--- a/Shared/Api/ModOptions/ModSettingsHandler.cs
+++ b/Shared/Api/ModOptions/ModSettingsHandler.cs
@@ -62,7 +62,23 @@ internal static class ModSettingsHandler
                     {
                         try
                         {
-                            mod.ModSettings[name].Load(token.ToObject<object>());
+                            var modSetting = mod.ModSettings[name];
+                            // Iterate until find ModSetting<> base class to get it's type
+                            var settingType = modSetting.GetType();
+                            var foundType = false;
+                            while(!foundType && settingType.BaseType != typeof(ModSetting) && settingType.BaseType != null)
+                            {
+                                settingType = settingType.BaseType;
+                                if (settingType.IsGenericType && settingType.GetGenericTypeDefinition() == typeof(ModSetting<>))
+                                {
+                                    // Load using the type from ModSetting<>
+                                    modSetting.Load(token.ToObject(settingType.GenericTypeArguments[0]));
+                                    foundType = true;
+                                }
+                            }
+                            // Load just from object if failed to find type
+                            if (!foundType)
+                                modSetting.Load(token.ToObject<object>());
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
- Passes the type of the mod setting into the json loader, otherwise enums load as longs rather that the original enum type.
- Set for the enum dropdown to be the loaded value rather than just the first value in the enum.