### PR TITLE
Fix for crashing subtowers on towerinventory

### DIFF
--- a/BloonsTD6 Mod Helper/Patches/Towers/TowerInventory_Init.cs
+++ b/BloonsTD6 Mod Helper/Patches/Towers/TowerInventory_Init.cs
@@ -32,16 +32,28 @@ internal static class TowerInventory_Init
 /// <summary>
 /// Prevent crashes for non-subtowers that aren't in the inventory
 /// </summary>
-[HarmonyPatch]
 internal static class TowerInventory_Patches
 {
-    private static System.Collections.Generic.IEnumerable<MethodBase> TargetMethods()
-    {
-        yield return AccessTools.Method(typeof(TowerInventory), nameof(TowerInventory.UpdatedTower));
-        yield return AccessTools.Method(typeof(TowerInventory), nameof(TowerInventory.DestroyedTower));
-        yield return AccessTools.Method(typeof(TowerInventory), nameof(TowerInventory.CreatedTower));
+    [HarmonyPatch(typeof(TowerInventory),"CreatedTower")]
+    public class TowerInventoryCreatedTower_Patch{
+        [HarmonyPrefix]
+        public static bool Prefix(ref TowerInventory __instance,ref TowerModel def){
+            if(!__instance.towerCounts.ContainsKey(def.baseId)){
+                __instance.towerCounts.Add(def.baseId,0);
+            }
+	        __instance.towerCounts[def.baseId]=__instance.towerCounts[def.baseId]+1;
+	        return false;
+        }
     }
-
-    [HarmonyPrefix]
-    private static bool Prefix(TowerInventory __instance, TowerModel def) => __instance.towerMaxes.ContainsKey(def.baseId);
+    [HarmonyPatch(typeof(TowerInventory),"DestroyedTower")]
+    public class TowerInventoryDestroyedTower_Patch{
+        [HarmonyPrefix]
+        public static bool Prefix(ref TowerInventory __instance,ref TowerModel def){
+            if(!__instance.towerCounts.ContainsKey(def.baseId)){
+                __instance.towerCounts.Add(def.baseId,0);
+            }
+		    __instance.towerCounts[def.baseId]=__instance.towerCounts[def.baseId]-1;
+		    return false;
+        }
+    }
 }


### PR DESCRIPTION
So, whatever was there previously wasn't exactly working as you can see by the unity log. This is based from my own digging with ida a while ago and (at least at the time) can confidently say this is what createdtower and destroyedtower does. Did notice updatedtower was being patched too but idfk what that does since i never got a crash with it so never bothered looking at it

https://github.com/Onixiya/SC2Expansion/blob/master/MiscPatches.cs#L127

[Player-prev.log](https://github.com/gurrenm3/BTD-Mod-Helper/files/12288580/Player-prev.log)

[Latest.log](https://github.com/gurrenm3/BTD-Mod-Helper/files/12288581/Latest.log)
