### PR TITLE
Add GetBloonDisplay to ModDisplay.cs

### DIFF
--- a/BloonsTD6 Mod Helper/Api/Display/ModDisplay.cs
+++ b/BloonsTD6 Mod Helper/Api/Display/ModDisplay.cs
@@ -169,6 +169,8 @@ public abstract class ModDisplay : ModContent
     /// <summary>
     /// Gets the Display for a given bloon
     /// <summary>
+    /// <param name="bloon"> The bloon base id</param>
+    /// <returns>The display GUID</returns>
     protected string GetBloonDisplay(string bloon) => 
         Game.instance.model.GetBloon(bloon).display.GUID;
     

--- a/BloonsTD6 Mod Helper/Api/Display/ModDisplay.cs
+++ b/BloonsTD6 Mod Helper/Api/Display/ModDisplay.cs
@@ -167,6 +167,12 @@ public abstract class ModDisplay : ModContent
         Game.instance.model.GetTower(tower, top, mid, bot).display.GUID;
 
     /// <summary>
+    /// Gets the Display for a given bloon
+    /// <summary>
+    protected string GetBloonDisplay(string bloon) => 
+        Game.instance.model.GetBloon(bloon).display.GUID;
+    
+    /// <summary>
     /// Gets a UnityDisplayNode for a different guid
     /// </summary>
     /// <param name="guid">The asset reference guid to get the node from</param>


### PR DESCRIPTION
Simply adds a quick way to get a bloon's display GUID. Wouldn't mind if it isn't added, it would just be nice to have since we already have one for towers.