### PR TITLE
Prevent the error caused from GetDamageModel, add GetDamageModels.

### DIFF
--- a/BloonsTD6 Mod Helper/Extensions/ModelExtensions/ProjectileModelExt.cs
+++ b/BloonsTD6 Mod Helper/Extensions/ModelExtensions/ProjectileModelExt.cs
@@ -19,8 +19,22 @@ public static class ProjectileModelExt
     /// <summary>
     /// Get the DamageModel behavior from the list of behaviors
     /// </summary>
-    public static DamageModel GetDamageModel(this ProjectileModel projectileModel) =>
-        projectileModel.GetBehavior<DamageModel>();
+    public static DamageModel GetDamageModel(this ProjectileModel projectileModel)
+    {
+        if (projectileModel.GetBehavior<DamageModel>() == null)
+        {
+            return projectileModel.GetDescendant<DamageModel>();
+        }
+        else
+        {
+            return projectileModel.GetBehavior<DamageModel>();
+        }
+    }
+    /// <summary>
+    /// Get all of the DamageModel behavior in this projectile and the DamageModel behaivors in the projectile's behaviors
+    /// </summary>
+    public static List<DamageModel> GetDamageModels(this ProjectileModel projectileModel) =>
+        projectileModel.GetDescendants<DamageModel>().ToList();
 
     /// <summary>
     /// Get all Projectile Simulations that have this ProjectileModel


### PR DESCRIPTION
Prevents the error caused from GetDamageModel if the projectile used on has the damage model in a behavior

Also added GetDamageModels which returns a list of every damage model in the projectile (behaviors and all)