### PR TITLE
Add GetBtd6Localization to StringExt.cs

### DIFF
--- a/BloonsTD6 Mod Helper/Extensions/SystemExtensions/StringExt.cs
+++ b/BloonsTD6 Mod Helper/Extensions/SystemExtensions/StringExt.cs
@@ -1,3 +1,4 @@
+using Il2CppNinjaKiwi.Common;
 using System.Globalization;
 using System.Text.RegularExpressions;
 namespace BTD_Mod_Helper.Extensions;
@@ -27,4 +28,34 @@ public static class StringExt
     /// <inheritdoc cref="TextInfo.ToTitleCase" />
     /// </summary>
     public static string ToTitleCase(this string input) => new CultureInfo("en-US", false).TextInfo.ToTitleCase(input);
+
+    /// <summary>
+    /// Gets the localization from the current localization text table, or the default one if it's not present in the current one. 
+    /// If the id is not present in any of these, returned as spaced or not spaced depending on parameters.
+    /// </summary>
+    /// <param name="id">The ID of the thing you're trying to get the localization of.</param>
+    /// <param name="returnAsSpacedIfNoEntry">Should this return the id with spaces if there's no localization present?</param>
+    /// <returns></returns>
+    public static string GetBtd6Localization(this string id, bool returnAsSpacedIfNoEntry = true)
+    {
+        if (LocalizationManager.Instance.textTable.ContainsKey(id))
+        {
+            return LocalizationManager.Instance.textTable[id];
+        }
+        else if (LocalizationManager.Instance.defaultTable.ContainsKey(id))
+        {
+            return LocalizationManager.Instance.defaultTable[id];
+        }
+        else
+        {
+            if (returnAsSpacedIfNoEntry)
+            {
+                return id.Spaced();
+            }
+            else
+            {
+                return id;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Example usage:

```cs
                ModHelperPanel mainPanel = InGame.instance.uiRect.gameObject.AddModHelperPanel(new("MainPanel", 1200, 750), VanillaSprites.MainBGPanelBlue);

                mainPanel.AddText(new("Title", 0, 225, 1200, 200), "Towers");

                List<string> towerDisplayNames = [];
                List<string> towerBaseIds = [];

                foreach (var towerModel in Game.instance.model.towers.ToList().FindAll(t => t.baseId == t.name))
                {
                    towerDisplayNames.Add(towerModel.baseId.GetBtd6Localization());
                    towerBaseIds.Add(towerModel.baseId);
                }

                mainPanel.AddDropdown(new("Dropdown", 0, -75, 850, 400), towerBaseIds.ToIl2CppList(), 1200, new Action<int>(index =>
                {
                    ModHelper.Log<BloonsTD6Mod>($"{towerBaseIds[index]}: {towerDisplayNames[index]}"); //Log the base id compared to the display name
                }));
```

This can also help with getting the display names of named mod content when not having access to the mod content