### PR TITLE
rework modtowerhelper.finalizehero skins, add gamemodel.getherowithnameandlevel patch

### DIFF
--- a/BloonsTD6 Mod Helper/Api/Internal/VanillaSpriteGenerator.cs
+++ b/BloonsTD6 Mod Helper/Api/Internal/VanillaSpriteGenerator.cs
@@ -107,7 +107,7 @@ internal static class VanillaSpriteGenerator
     {
         if (Regex.Match(name, @"^\d\d\d-").Success)
         {
-            name = string.Concat(name.Split('-').Reverse());
+            name = string.Concat(name.Split('-').AsEnumerable().Reverse());
         }
 
         if (name.Contains('#'))

--- a/BloonsTD6 Mod Helper/Api/Towers/ModHero.cs
+++ b/BloonsTD6 Mod Helper/Api/Towers/ModHero.cs
@@ -276,8 +276,8 @@ public abstract class ModHero : ModTower
     /// <summary>
     /// Creates the SkinData for the default tower
     /// </summary>
-    /// <param name="skinsByName">Existing hero skins by their skin/tower name</param>
-    public virtual SkinData CreateDefaultSkin(Dictionary<string, SkinData> skinsByName)
+    /// <param name="skins">Existing hero skins</param>
+    public virtual SkinData CreateDefaultSkin(SkinData[]skins)
     {
         var skinData = ScriptableObject.CreateInstance<SkinData>();
         skinData.name = skinData.baseTowerName = Id;
@@ -297,9 +297,9 @@ public abstract class ModHero : ModTower
         };
 
         skinData.textMaterialId = NameStyle;
-        skinData.fontMaterial = GetFontMaterial(skinsByName);
-        skinData.backgroundBanner = GetBackgroundBanner(skinsByName);
-        skinData.backgroundColourTintOverride = GetBackgroundColor(skinsByName);
+        skinData.fontMaterial=skins.First(skin=>skin.name==NameStyle).fontMaterial;
+        skinData.backgroundBanner = skins.First(skin=>skin.name==BackgroundStyle).backgroundBanner;
+        skinData.backgroundColourTintOverride = skins.First(skin=>skin.name==GlowStyle).backgroundColourTintOverride;
 
         skinData.StorePortraitsContainer = new PortraitContainer
         {

--- a/BloonsTD6 Mod Helper/Api/Towers/ModTowerHelper.cs
+++ b/BloonsTD6 Mod Helper/Api/Towers/ModTowerHelper.cs
@@ -286,8 +286,7 @@ public static class ModTowerHelper
             Game.instance.model.AddHeroDetails(heroDetailsModel, index);
 
             var skinsData = GameData.Instance.skinsData;
-            var skinsByName = skinsData.SkinList.items.ToDictionary(data => data.name, data => data);
-            var skinData = modHero.CreateDefaultSkin(skinsByName);
+            var skinData = modHero.CreateDefaultSkin(skinsData.SkinList.items);
             skinsData.AddSkins(new[] {skinData});
         }
     }

--- a/BloonsTD6 Mod Helper/Patches/Model/GameModel_CreateModded.cs
+++ b/BloonsTD6 Mod Helper/Patches/Model/GameModel_CreateModded.cs
@@ -35,6 +35,27 @@ internal static class GameModel_CreateModded2
     }
 }
 
+[HarmonyPatch(typeof(GameModel),nameof(GameModel.GetHeroWithNameAndLevel))]
+internal static class GameModel_GetHeroWithNameAndLevel{
+    public static bool Prefix(GameModel __instance, string name, int tier, ref TowerModel __result){
+        if(ModTowerHelper.TowerCache.ContainsKey(name))
+        {
+            if(tier == 1)
+            {
+                __result = __instance.GetTowerFromId(name);
+            }
+            else
+            {
+                __result=__instance.GetTowerFromId(name+" "+tier);
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}
+
 [HarmonyPatch(typeof(GameModel), nameof(GameModel.CreateModded), typeof(GameModel), typeof(List<ModModel>),
     typeof(List<RelicKnowledgeItemBase>))]
 internal static class GameModel_CreateModded


### PR DESCRIPTION
pr is made with a incompatibility with my stuff and mod helper a user has noticed.

rework modtowerhelper.finalizehero skins to not use a dictionary and directly read from the skinlist.items array for skin related data. add gamemodel.getherowithnameandlevel patch which appears to be the method responsible for breaking heroupgradedetails.binddetails this time.

also a change to vanillaspritegenerator so the damn thing would compile. I have 0 idea if it works but it compiles so idgaf.

i've left the getfontmaterial, getbackgroundbanner and getbackgroundcolour methods there as while they don't appear to be used in other places in mod helper, they might be used in other mods as they are public so idfk if you want to deprecate those.

https://discord.com/channels/504782676331331584/872504918831939625/1396121155982721135