### PR TITLE
Add support for links within ModsMenu.cs

### DIFF
--- a/BloonsTD6 Mod Helper/Api/Components/ModHelperLinkSupport.cs
+++ b/BloonsTD6 Mod Helper/Api/Components/ModHelperLinkSupport.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using BTD_Mod_Helper.Api.Helpers;
+using Il2CppTMPro;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+namespace BTD_Mod_Helper.Api.Components;
+
+/// <summary>
+/// Allows links created by rich text within TextMeshPro to be clicked and opened with <see cref="ProcessHelper.OpenURL"/>. Since this is not a ModHelperComponent, add it like any normal mono behaviour.
+/// </summary>
+[RegisterTypeInIl2Cpp(false)]
+public class ModHelperLinkSupport : MonoBehaviour
+{
+    private TMP_Text textMeshPro;
+    private EventTrigger trigger;
+    private EventTrigger.Entry entry;
+
+    private Action<BaseEventData> onClick;
+
+    private void Awake()
+    {
+        textMeshPro = GetComponent<TMP_Text>();
+        
+        trigger = gameObject.GetComponent<EventTrigger>();
+        if (!trigger)
+        {
+            trigger = gameObject.AddComponent<EventTrigger>();
+        }
+        entry = new EventTrigger.Entry { eventID = EventTriggerType.PointerClick };
+        onClick = data => OnClick(data);
+        entry.callback.AddListener(onClick);
+        trigger.triggers.Add(entry);
+    }
+
+    private void OnDisable()
+    {
+        if (trigger != null && entry != null)
+        {
+            trigger.triggers.Remove(entry);
+            entry.callback.RemoveListener(onClick);
+        }
+    }
+    
+    private void OnClick(BaseEventData data)
+    {
+        var eventData = data.Cast<PointerEventData>();
+        
+        int linkIndex = TMP_TextUtilities.FindIntersectingLink(textMeshPro, eventData.position, eventData.pressEventCamera);
+        if (linkIndex != -1)
+        {
+            TMP_LinkInfo linkInfo = textMeshPro.textInfo.linkInfo[linkIndex];
+            string link = linkInfo.GetLinkID();
+            ProcessHelper.OpenURL(link);
+        }
+    }
+}

--- a/BloonsTD6 Mod Helper/UI/Menus/ModsMenu.cs
+++ b/BloonsTD6 Mod Helper/UI/Menus/ModsMenu.cs
@@ -683,6 +683,7 @@ internal class ModsMenu : ModGameMenu<ExtraSettingsScreen>
         selectedModDescription.Text.enableAutoSizing = true;
         selectedModDescription.Text.lineSpacing = Padding / 2f;
         selectedModDescription.Text.font = Fonts.Btd6FontBody;
+        selectedModDescription.Text.gameObject.AddComponent<ModHelperLinkSupport>();
 
         var buttonsRow = selectedModPanel.AddPanel(new Info("ButtonRow")
         {


### PR DESCRIPTION
-> Added new component ModHelperLinkSupport.cs to api, this component allows links created by rich text within TMP_Text (including NK versions) components to be clickable and open in the default browser
-> Added this component to the Mod Description text field in the mods menu allowing for links in mod descriptions to be clickable