### PR TITLE
Add a way to save data persistently between sessions easier.

### DIFF
--- a/BloonsTD6 Mod Helper/Api/ModSaveData.cs
+++ b/BloonsTD6 Mod Helper/Api/ModSaveData.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using Il2CppAssets.Scripts.Models.Profile;
+namespace BTD_Mod_Helper.Api;
+
+/// <summary>
+/// Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
+/// </summary>
+public abstract class ModSaveData : ModContent
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public override void Register()
+    {
+        
+    }
+
+    /// <summary>
+    /// Saves this ModSaveData using the returned encoded string.
+    /// </summary>
+    /// <returns>The encoded save data.</returns>
+    public abstract string Save();
+    /// <summary>
+    /// Loads this ModSaveData from the provided encoded string.
+    /// </summary>
+    /// <param name="data">The encoded save data.</param>
+    public abstract void Load(string data);
+    
+    internal static void SaveAll(MapSaveDataModel save)
+    {
+        try
+        {
+            HashSet<string> saved = new HashSet<string>();
+            foreach (var saveData in GetContent<ModSaveData>())
+            {
+                try
+                {
+                    if (!saved.Add(saveData.Id))
+                    {
+                        ModHelper.Warning($"Mod save data with ID {saveData.Id} is already saved! Skipping.");
+                        continue;
+                    }
+
+                    string data = saveData.Save();
+                    save.metaData.Add(saveData.Id, data);
+                }
+                catch (Exception e)
+                {
+                    ModHelper.Error($"Failed to save {saveData.Id}!");
+                    ModHelper.Error(e);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            ModHelper.Error("Error saving mod data!");
+            ModHelper.Error(e);
+            throw;
+        }
+    }
+
+    internal static void LoadAll(MapSaveDataModel save)
+    {
+        try
+        {
+            foreach (var saveData in GetContent<ModSaveData>())
+            {
+                try
+                {
+                    if (!save.metaData.TryGetValue(saveData.Id, out string data))
+                    {
+                        continue;
+                    }
+                    
+                    saveData.Load(data);
+                }
+                catch (Exception e)
+                {
+                    ModHelper.Error($"Failed to load {saveData.Id}!");
+                    ModHelper.Error(e);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            ModHelper.Error("Error loading mod data!");
+            ModHelper.Error(e);
+            throw;
+        }
+    }
+}

--- a/BloonsTD6 Mod Helper/Api/Towers/ModTowerSaveData.cs
+++ b/BloonsTD6 Mod Helper/Api/Towers/ModTowerSaveData.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Il2CppAssets.Scripts.Models.Profile;
+using Il2CppAssets.Scripts.Simulation.Towers;
+namespace BTD_Mod_Helper.Api.Towers;
+
+/// <summary>
+/// Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
+/// </summary>
+public abstract class ModTowerSaveData : ModContent
+{
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public override void Register()
+    {
+    }
+
+    /// <summary>
+    /// The associated base tower id of this ModTowerSaveData.
+    /// </summary>
+    public abstract string TowerBaseId { get; }
+
+    /// <summary>
+    /// Returns whether this ModTowerSaveData should save for the provided tower or not.
+    /// </summary>
+    /// <param name="tower">The tower to save for</param>
+    /// <returns>Whether this ModTowerSaveData should save this tower or not.</returns>
+    public virtual bool ShouldSave(Tower tower)
+    {
+        return tower.towerModel.BaseId == TowerBaseId;
+    }
+    
+    /// <summary>
+    /// Saves this ModSaveData using the returned encoded string.
+    /// </summary>
+    /// <returns>The encoded save data.</returns>
+    /// <param name="tower">The tower getting saved.</param>
+    public abstract string Save(Tower tower);
+
+    /// <summary>
+    /// Loads this ModSaveData from the provided encoded string.
+    /// </summary>
+    /// <param name="data">The encoded save data.</param>
+    /// <param name="tower">The tower getting loaded.</param>
+    public abstract void Load(string data, Tower tower);
+
+    internal static void LoadAll(Tower tower, TowerSaveDataModel towerData)
+    {
+        try
+        {
+            foreach (var saveData in GetContent<ModTowerSaveData>().Where(saveData => saveData.ShouldSave(tower)))
+            {
+                if (towerData.metaData.TryGetValue(saveData.Id, out string data))
+                {
+                    try
+                    {
+                        saveData.Load(data, tower);
+                    }
+                    catch (Exception e)
+                    {
+                        ModHelper.Error($"Failed to save {saveData.Id}!");
+                        ModHelper.Error(e);
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            ModHelper.Error($"Failed to load all ModTowerSaveData for tower ${tower.towerModel.name} ({tower.Id})!");
+            ModHelper.Error(e);
+            throw;
+        }
+    }
+    internal static void SaveAll(Tower tower, TowerSaveDataModel towerData)
+    {
+        try
+        {
+            HashSet<string> saved = new HashSet<string>();
+            foreach (var saveData in GetContent<ModTowerSaveData>().Where(saveData => saveData.ShouldSave(tower)))
+            {
+                if (!saved.Add(saveData.Id))
+                {
+                    ModHelper.Warning($"Mod save data with ID {saveData.Id} is already saved! Skipping.");
+                    continue;
+                }
+                try
+                {
+                    string data = saveData.Save(tower);
+                    towerData.metaData.Add(saveData.Id, data);
+                }
+                catch (Exception e)
+                {
+                    ModHelper.Error($"Failed to save {saveData.Id}!");
+                    ModHelper.Error(e);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            ModHelper.Error($"Failed to save all ModTowerSaveData for tower ${tower.towerModel.name} ({tower.Id})!");
+            ModHelper.Error(e);
+            throw;
+        }
+    }
+}
+
+/// <summary>
+/// Generic version of <see cref="ModTowerSaveData"/>.
+/// </summary>
+public abstract class ModTowerSaveData<T> : ModTowerSaveData where T : ModTower
+{
+    public override string TowerBaseId => ModContent.TowerID<T>();
+}

--- a/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
+++ b/BloonsTD6 Mod Helper/BloonsTD6Mod.cs
@@ -523,7 +523,7 @@ public abstract class BloonsTD6Mod : BloonsMod
     /// <summary>
     /// Called at the end of each round when a Tower's data is saved
     /// <br />
-    /// Use saveData.metaData to save custom information
+    /// Use saveData.metaData to save custom information. You can also use a ModTowerSaveData to make this easier.
     /// <br />
     /// Equivalent to a HarmonyPostFix on Tower.GetSaveData
     /// </summary>
@@ -534,7 +534,7 @@ public abstract class BloonsTD6Mod : BloonsMod
     /// <summary>
     /// Called when you load a save file and a Tower's save data get loaded for the tower
     /// <br />
-    /// Use saveData.metaData to load custom information
+    /// Use saveData.metaData to load custom information. You can also use a ModTowerSaveData to make this easier.
     /// <br />
     /// Equivalent to a HarmonyPostFix on Tower.SetSaveData
     /// </summary>

--- a/BloonsTD6 Mod Helper/Patches/Maps/Map_GetSaveData.cs
+++ b/BloonsTD6 Mod Helper/Patches/Maps/Map_GetSaveData.cs
@@ -1,0 +1,13 @@
+﻿using BTD_Mod_Helper.Api;
+using Il2CppAssets.Scripts.Models.Profile;
+using Il2CppAssets.Scripts.Simulation.Track;
+namespace BTD_Mod_Helper.Patches;
+
+[HarmonyPatch(typeof(Map), nameof(Map.GetSaveData))]
+internal static class Map_GetSaveData
+{
+    public static void Postfix(MapSaveDataModel mapData)
+    {
+        ModSaveData.SaveAll(mapData);
+    }
+}

--- a/BloonsTD6 Mod Helper/Patches/Maps/Map_GetSaveData.cs
+++ b/BloonsTD6 Mod Helper/Patches/Maps/Map_GetSaveData.cs
@@ -1,5 +1,6 @@
 ﻿using BTD_Mod_Helper.Api;
 using Il2CppAssets.Scripts.Models.Profile;
+using Il2CppAssets.Scripts.Simulation.Towers;
 using Il2CppAssets.Scripts.Simulation.Track;
 namespace BTD_Mod_Helper.Patches;
 

--- a/BloonsTD6 Mod Helper/Patches/Maps/Map_SetSaveData.cs
+++ b/BloonsTD6 Mod Helper/Patches/Maps/Map_SetSaveData.cs
@@ -1,0 +1,13 @@
+﻿using BTD_Mod_Helper.Api;
+using Il2CppAssets.Scripts.Models.Profile;
+using Il2CppAssets.Scripts.Simulation.Track;
+namespace BTD_Mod_Helper.Patches;
+
+[HarmonyPatch(typeof(Map), nameof(Map.SetSaveData))]
+internal static class Map_SetSaveData
+{
+    public static void Postfix(MapSaveDataModel mapData)
+    {
+        ModSaveData.LoadAll(mapData);
+    }
+}

--- a/BloonsTD6 Mod Helper/Patches/Towers/Tower_GetSaveData.cs
+++ b/BloonsTD6 Mod Helper/Patches/Towers/Tower_GetSaveData.cs
@@ -1,4 +1,5 @@
-﻿using Il2CppAssets.Scripts.Models.Profile;
+﻿using BTD_Mod_Helper.Api.Towers;
+using Il2CppAssets.Scripts.Models.Profile;
 using Il2CppAssets.Scripts.Simulation.Towers;
 namespace BTD_Mod_Helper.Patches.Towers;
 
@@ -10,5 +11,7 @@ internal class Tower_GetSaveData
     {
         if (__instance == null) return;
         ModHelper.PerformHook(mod => mod.OnTowerSaved(__instance, __result));
+        
+        ModTowerSaveData.SaveAll(__instance, __result);
     }
 }

--- a/BloonsTD6 Mod Helper/Patches/Towers/Tower_SetSaveData.cs
+++ b/BloonsTD6 Mod Helper/Patches/Towers/Tower_SetSaveData.cs
@@ -1,4 +1,9 @@
-﻿using Il2CppAssets.Scripts.Models.Profile;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BTD_Mod_Helper.Api;
+using BTD_Mod_Helper.Api.Towers;
+using Il2CppAssets.Scripts.Models.Profile;
 using Il2CppAssets.Scripts.Simulation.Towers;
 namespace BTD_Mod_Helper.Patches.Towers;
 
@@ -10,5 +15,7 @@ internal class Tower_SetSaveData
     {
         if (__instance == null) return;
         ModHelper.PerformHook(mod => mod.OnTowerLoaded(__instance, towerData));
+
+        ModTowerSaveData.LoadAll(__instance, towerData);
     }
 }

--- a/Documentation/BTD_Mod_Helper.Api.ModSaveData.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModSaveData.md
@@ -1,7 +1,7 @@
 #### [BloonsTD6 Mod Helper](README.md 'README')
 ### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
 
-## Animations Class
+## ModSaveData Class
 
 Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
 
@@ -14,7 +14,7 @@ Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.O
 
 <a name='BTD_Mod_Helper.Api.ModSaveData.Save()'></a>
 
-## Animations.Save() Method
+## ModSaveData.Save() Method
 
 Saves this ModSaveData using the returned encoded string.
 
@@ -36,7 +36,7 @@ public abstract void Load(string data);
 ```
 #### Parameters
 
-<a name='BTD_Mod_Helper.Api.Animations.Get(string).data'></a>
+<a name='BTD_Mod_Helper.Api.ModSaveData.Load(string).data'></a>
 
 `data` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
 The encoded save data.

--- a/Documentation/BTD_Mod_Helper.Api.ModSaveData.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModSaveData.md
@@ -1,0 +1,42 @@
+#### [BloonsTD6 Mod Helper](README.md 'README')
+### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
+
+## Animations Class
+
+Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
+
+```csharp
+public abstract class ModSaveData : ModContent
+```
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [ModContent](https://github.com/gurrenm3/BTD-Mod-Helper/blob/master/Documentation/BTD_Mod_Helper.Api.ModContent.md 'ModConent') &#129106; ModSaveData
+### Methods
+
+<a name='BTD_Mod_Helper.Api.ModSaveData.Save()'></a>
+
+## Animations.Save() Method
+
+Saves this ModSaveData using the returned encoded string.
+
+```csharp
+public abstract string Save();
+```
+
+<a name='BTD_Mod_Helper.Api.ModSaveData.Load(string)'></a>
+
+#### Returns
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String') The encoded save data.
+
+## ModSaveData.Load(string) Method
+
+Loads this ModSaveData from the provided encoded string.
+
+```csharp
+public abstract void Load(string data);
+```
+#### Parameters
+
+<a name='BTD_Mod_Helper.Api.Animations.Get(string).data'></a>
+
+`data` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+The encoded save data.

--- a/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData.md
@@ -1,5 +1,5 @@
 #### [BloonsTD6 Mod Helper](README.md 'README')
-### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
+### [BTD_Mod_Helper.Api.Towers](README.md#BTD_Mod_Helper.Api.Towers 'BTD_Mod_Helper.Api.Towers')
 
 ## ModTowerSaveData Class
 

--- a/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData.md
@@ -1,0 +1,88 @@
+#### [BloonsTD6 Mod Helper](README.md 'README')
+### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
+
+## ModTowerSaveData Class
+
+Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
+
+```csharp
+public abstract class ModTowerSaveData : ModContent
+```
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [ModContent](https://github.com/gurrenm3/BTD-Mod-Helper/blob/master/Documentation/BTD_Mod_Helper.Api.ModContent.md 'ModConent') &#129106; ModTowerSaveData
+
+### Properties
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.TowerBaseId'></a>
+
+## ModTowerSaveData.TowerBaseId
+
+The associated base tower id of this ModTowerSaveData.
+```cs
+public abstract string TowerBaseId { get; }
+```
+
+#### Property Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+### Methods
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.ShouldSave(Tower)'></a>
+
+## ModTowerSaveData.ShouldSave(Tower) Method
+
+Returns whether this ModTowerSaveData should save for the provided tower or not.
+
+```csharp
+public virtual bool ShouldSave(Tower tower);
+```
+
+#### Parameters
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.ShouldSave(Tower).tower'></a>
+
+`tower` [Il2CppAssets.Scripts.Simulation.Towers.Tower](https://docs.microsoft.com/en-us/dotnet/api/Il2CppAssets.Scripts.Simulation.Towers.Tower 'Il2CppAssets.Scripts.Simulation.Towers.Tower')
+The tower to save/load for
+
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.Boolean') Whether this ModTowerSaveData should save this tower or not.
+
+## ModTowerSaveData.Save(Tower) Method
+
+Saves this ModTowerSaveData using the returned encoded string for the provided tower.
+
+```csharp
+public abstract string Save(Tower tower);
+```
+
+#### Parameters
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.Save(Tower).tower'></a>
+
+`tower` [Il2CppAssets.Scripts.Simulation.Towers.Tower](https://docs.microsoft.com/en-us/dotnet/api/Il2CppAssets.Scripts.Simulation.Towers.Tower 'Il2CppAssets.Scripts.Simulation.Towers.Tower')
+The tower getting saved.
+
+
+#### Returns
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String') The encoded save data.
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.Load(string, Tower)'></a>
+
+## ModTowerSaveData.Load(string, ModTowerSaveData) Method
+
+Loads this ModTowerSaveData from the provided encoded string for the provided tower.
+
+```csharp
+public abstract void Load(string data);
+```
+#### Parameters
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.Load(string, Tower).data'></a>
+
+`data` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+The encoded save data.
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.Load(string, Tower).tower'></a>
+
+`tower` [Il2CppAssets.Scripts.Simulation.Towers.Tower](https://docs.microsoft.com/en-us/dotnet/api/Il2CppAssets.Scripts.Simulation.Towers.Tower 'Il2CppAssets.Scripts.Simulation.Towers.Tower')
+The tower getting loaded.

--- a/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData_T_.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData_T_.md
@@ -1,0 +1,32 @@
+#### [BloonsTD6 Mod Helper](README.md 'README')
+### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
+
+## ModTowerSaveData Class
+
+Mod Content class to easily save and load data that should persist between sessions. All saved data are strings.
+
+```csharp
+public abstract class ModTowerSaveData<T> : ModTowerSaveData 
+    where T : ModTower
+```
+#### Type parameters
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData_T_.T'></a>
+
+`T`
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [ModContent](https://github.com/gurrenm3/BTD-Mod-Helper/blob/master/Documentation/BTD_Mod_Helper.Api.ModContent.md 'ModConent') &#129106; [ModTowerSaveData](https://github.com/gurrenm3/BTD-Mod-Helper/blob/master/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData.md) &#129106; ModTowerSaveData
+
+### Properties
+
+<a name='BTD_Mod_Helper.Api.ModTowerSaveData.TowerBaseId'></a>
+
+## ModTowerSaveData.TowerBaseId
+
+The associated base tower id of this ModTowerSaveData.
+```cs
+public override string TowerBaseId { get; }
+```
+
+#### Property Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')

--- a/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData_T_.md
+++ b/Documentation/BTD_Mod_Helper.Api.ModTowerSaveData_T_.md
@@ -1,5 +1,5 @@
 #### [BloonsTD6 Mod Helper](README.md 'README')
-### [BTD_Mod_Helper.Api](README.md#BTD_Mod_Helper.Api 'BTD_Mod_Helper.Api')
+### [BTD_Mod_Helper.Api.Towers](README.md#BTD_Mod_Helper.Api.Towers 'BTD_Mod_Helper.Api.Towers')
 
 ## ModTowerSaveData Class
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -34,8 +34,6 @@
 | [ModMenuData](BTD_Mod_Helper.Api.ModMenuData.md 'BTD_Mod_Helper.Api.ModMenuData') | Class to be passed in to the Open methods of Screens |
 | [ModSaveData](BTD_Mod_Helper.Api.ModSaveData.md 'BTD_Mod_Helper.Api.ModSaveData') | Class to make saving persistent data easier. |
 | [ModSourceFileGenerator](BTD_Mod_Helper.Api.ModSourceFileGenerator.md 'BTD_Mod_Helper.Api.ModSourceFileGenerator') | ModContent class for code/data generators that write files into a mod project's source code.<br/>per output. |
-| [ModTowerSaveData](BTD_Mod_Helper.Api.ModTowerSaveData.md 'BTD_Mod_Helper.Api.ModTowerSaveData') | Class to make saving persistent data easier related to towers easier. |
-| [ModTowerSaveData&lt;T&gt;](BTD_Mod_Helper.Api.ModTowerSaveData_T_.md 'BTD_Mod_Helper.Api.ModTowerSaveData<T>') | Generic class to make a ModTowerSaveData for a [ModTower](BTD_Mod_Helper.Api.Towers.ModTower) |
 | [MoreAccessTools](BTD_Mod_Helper.Api.MoreAccessTools.md 'BTD_Mod_Helper.Api.MoreAccessTools') | Further methods along the lines of Harmony's [HarmonyLib.AccessTools](https://docs.microsoft.com/en-us/dotnet/api/HarmonyLib.AccessTools 'HarmonyLib.AccessTools') |
 | [NamedModContent](BTD_Mod_Helper.Api.NamedModContent.md 'BTD_Mod_Helper.Api.NamedModContent') | ModContent with DisplayName and Description that registers values in the LocalizationManger's textTable |
 | [TaskScheduler](BTD_Mod_Helper.Api.TaskScheduler.md 'BTD_Mod_Helper.Api.TaskScheduler') | Class for scheduling Tasks using MelonCoroutines |
@@ -377,6 +375,9 @@
 | [ModTowerSet](BTD_Mod_Helper.Api.Towers.ModTowerSet.md 'BTD_Mod_Helper.Api.Towers.ModTowerSet') | A custom collection of ModTowers |
 | [ModTsmTheme](BTD_Mod_Helper.Api.Towers.ModTsmTheme.md 'BTD_Mod_Helper.Api.Towers.ModTsmTheme') | ModContent for defining a new Tower Selection Menu Theme that towers can use.<br/><example>
 <br/><br/>towerModel.towerSelectionMenuThemeId = ModContent.GetId&lt;MyModTsmTheme&gt;();
+
+| [ModTowerSaveData](BTD_Mod_Helper.Api.ModTowerSaveData.md 'BTD_Mod_Helper.Api.ModTowerSaveData') | Class to make saving persistent data easier related to towers easier. |
+| [ModTowerSaveData&lt;T&gt;](BTD_Mod_Helper.Api.ModTowerSaveData_T_.md 'BTD_Mod_Helper.Api.ModTowerSaveData<T>') | Generic class to make a ModTowerSaveData for a [ModTower](BTD_Mod_Helper.Api.Towers.ModTower) |
 <br/></code>
  |
 | [ModUpgrade](BTD_Mod_Helper.Api.Towers.ModUpgrade.md 'BTD_Mod_Helper.Api.Towers.ModUpgrade') | A class used to create an Upgrade for a Tower |

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -32,7 +32,10 @@
 | [ModGameMenu&lt;T&gt;](BTD_Mod_Helper.Api.ModGameMenu_T_.md 'BTD_Mod_Helper.Api.ModGameMenu<T>') | Generic class for creating a ModGameMenu with the given type as it's base menu |
 | [ModLoadTask](BTD_Mod_Helper.Api.ModLoadTask.md 'BTD_Mod_Helper.Api.ModLoadTask') | Class for a Coroutine style task that runs during the BTD6 loading screen |
 | [ModMenuData](BTD_Mod_Helper.Api.ModMenuData.md 'BTD_Mod_Helper.Api.ModMenuData') | Class to be passed in to the Open methods of Screens |
+| [ModSaveData](BTD_Mod_Helper.Api.ModSaveData.md 'BTD_Mod_Helper.Api.ModSaveData') | Class to make saving persistent data easier. |
 | [ModSourceFileGenerator](BTD_Mod_Helper.Api.ModSourceFileGenerator.md 'BTD_Mod_Helper.Api.ModSourceFileGenerator') | ModContent class for code/data generators that write files into a mod project's source code.<br/>per output. |
+| [ModTowerSaveData](BTD_Mod_Helper.Api.ModTowerSaveData.md 'BTD_Mod_Helper.Api.ModTowerSaveData') | Class to make saving persistent data easier related to towers easier. |
+| [ModTowerSaveData&lt;T&gt;](BTD_Mod_Helper.Api.ModTowerSaveData_T_.md 'BTD_Mod_Helper.Api.ModTowerSaveData<T>') | Generic class to make a ModTowerSaveData for a [ModTower](BTD_Mod_Helper.Api.Towers.ModTower) |
 | [MoreAccessTools](BTD_Mod_Helper.Api.MoreAccessTools.md 'BTD_Mod_Helper.Api.MoreAccessTools') | Further methods along the lines of Harmony's [HarmonyLib.AccessTools](https://docs.microsoft.com/en-us/dotnet/api/HarmonyLib.AccessTools 'HarmonyLib.AccessTools') |
 | [NamedModContent](BTD_Mod_Helper.Api.NamedModContent.md 'BTD_Mod_Helper.Api.NamedModContent') | ModContent with DisplayName and Description that registers values in the LocalizationManger's textTable |
 | [TaskScheduler](BTD_Mod_Helper.Api.TaskScheduler.md 'BTD_Mod_Helper.Api.TaskScheduler') | Class for scheduling Tasks using MelonCoroutines |
@@ -372,7 +375,10 @@
 | [ModTower&lt;T&gt;](BTD_Mod_Helper.Api.Towers.ModTower_T_.md 'BTD_Mod_Helper.Api.Towers.ModTower<T>') | A convenient generic class for specifying the ModTowerSet that a ModTower uses |
 | [ModTowerHelper](BTD_Mod_Helper.Api.Towers.ModTowerHelper.md 'BTD_Mod_Helper.Api.Towers.ModTowerHelper') | Class with helper methods for TowerModels / ModTowers<br/><br/><br/>Mostly used internally |
 | [ModTowerSet](BTD_Mod_Helper.Api.Towers.ModTowerSet.md 'BTD_Mod_Helper.Api.Towers.ModTowerSet') | A custom collection of ModTowers |
-| [ModTsmTheme](BTD_Mod_Helper.Api.Towers.ModTsmTheme.md 'BTD_Mod_Helper.Api.Towers.ModTsmTheme') | ModContent for defining a new Tower Selection Menu Theme that towers can use.<br/><example><br/><br/>towerModel.towerSelectionMenuThemeId = ModContent.GetId&lt;MyModTsmTheme&gt;();<br/></code> |
+| [ModTsmTheme](BTD_Mod_Helper.Api.Towers.ModTsmTheme.md 'BTD_Mod_Helper.Api.Towers.ModTsmTheme') | ModContent for defining a new Tower Selection Menu Theme that towers can use.<br/><example>
+<br/><br/>towerModel.towerSelectionMenuThemeId = ModContent.GetId&lt;MyModTsmTheme&gt;();
+<br/></code>
+ |
 | [ModUpgrade](BTD_Mod_Helper.Api.Towers.ModUpgrade.md 'BTD_Mod_Helper.Api.Towers.ModUpgrade') | A class used to create an Upgrade for a Tower |
 | [ModUpgrade&lt;T&gt;](BTD_Mod_Helper.Api.Towers.ModUpgrade_T_.md 'BTD_Mod_Helper.Api.Towers.ModUpgrade<T>') | A convenient generic class for specifying the ModTower that this ModUpgrade is for |
 | [ModVanillaContent](BTD_Mod_Helper.Api.Towers.ModVanillaContent.md 'BTD_Mod_Helper.Api.Towers.ModVanillaContent') | Class for changing Vanilla content within the game |

--- a/Wiki/Saving-Persistent-Data.md
+++ b/Wiki/Saving-Persistent-Data.md
@@ -1,0 +1,156 @@
+---
+title: Saving Persistent Data
+---
+**This guide assumes that you already have at least a basic knowledge of C#, and have set up a modding environment as explained on this wiki.**
+
+Mod Helper has a system to save data that should be persistent between sessions inside of a match. There's not a very obvious way to do this, which is why this exists. There may be a few things you'd like to save between sessions, such as a currency, something related to a custom behavior you have made, etc.
+
+# [ModSaveData](/docs/BTD_Mod_Helper.Api.ModSaveData)
+
+This is the class you want to inherit from when you want to easily save and load data. It's very simple to create a ModSaveData class. All you need to do is override the `Save()` and `Load(string)` methods. All saved data are strings. You should use this when you want to save something not specific to anything. Here is a basic, generic, example:
+
+```cs
+public class MySaveData : ModSaveData
+{
+    public override string Save()
+    {
+        return Some.String.Somewhere;
+    }
+
+    public override void Load(string data)
+    {
+        Some.String.Somewhere = data;
+    }
+}
+```
+
+A common way to save any data as a string is using JSON. Mod Helper comes with Newtonsoft's Json.NET. This library has an easy to use way to convert anything to JSON. The `Newtonsoft.Json.JsonConvert` static class. This class comes with a few helper methods. The main two you'll use are `SerializeObject(object?)` and `DeserializeObject<T>(string)`
+
+Json.NET also comes with an alternative way to serialize objects to JSON, JObjects and JTokens. These are much more convuluted than using JsonConvert. If you want to save an object from IL2CPP then use Mod Helper's [Il2CppJsonConvert](/docs/BTD_Mod_Helper.Api.Internal.Il2CppJsonConvert)
+
+Using JSON allows you to save more complicated values without needing to make your own parsers. However, **any recurssion can cause freezing or an exception to be thrown, meaning your data won't be saved or loaded.** To prevent this from happening, you'll want a custom `Newtonsoft.Json.JsonSerializerSettings`. When serializing, you want to create a new one of these with `ReferenceLoopHandling` set to `Newtonsoft.Json.ReferenceLoopHandling.Ignore`.
+
+Don't worry about catching exceptions during saving and loading unless you want to do something after an exception is thrown. Mod Helper will catch any thrown exceptions for you.
+
+Here's an example using `Newtonsoft.Json.JsonConvert` and a custom save data class.
+
+```cs
+using System.Collections.Generic;
+using BTD_Mod_Helper.Api;
+using Newstonsoft.Json;
+
+public class Save
+{
+    public Dictionary<string, int> MutationsCountById = [];
+    public double DnaAmount = 0;
+}
+
+public class MyMod : BloonsTD6Mod
+{
+    // Modify SaveData somewhere in your mod.
+    public static Save SaveData = new Save();
+
+    public override void OnMatchEnd()
+    {
+        SaveData = new Save();
+    }
+
+    public override void OnRestart()
+    {
+        SaveData = new Save();
+    }
+}
+
+public class MySaveData : ModSaveData
+{
+    public override string Save()
+    {
+        return JsonConvert.SerializeObject(MyMod.SaveData);
+    }
+
+    public override void Load(string data)
+    {
+        MyMod.Savedata = JsonConvert.DeserializeObject<Save>(data);
+        // Handle applying the save here
+    }
+}
+```
+
+Mod Helper also provides a way to save per-tower data. 
+
+# [ModTowerSaveData](/docs/BTD_Mod_Helper.Api.ModTowerSaveData)
+
+You want to inherit from this class every time you are saving something related to towers if each tower will have it's own thing. There are two methods you must override. `Save(Il2CppAssets.Scripts.Simulation.Towers.Tower)` and `Load(string, Il2CppAssets.Scripts.Simulation.Towers.Tower)`. There is also one property you must override, `TowerBaseId`.
+
+If you are saving this for a [ModTower](/docs/BTD_Mod_Helper.Api.Towers.ModTower), then you can use `ModTowerSaveData<T>` where `T` is a `ModTower`. This sets `TowerBaseId` to the base id of the provided `ModTower` If you want to learn how to use ModTowers, you can do so [here.](/wiki/Making-a-Custom-Tower)
+
+You can also optionally (and probably should) override the `ShouldSave(Il2CppAssets.Scripts.Simulation.Towers.Tower)` method. This returns a bool and tells mod helper whether or not it should save the tower. By default all it does is check if the tower's tower model base id is the same as the `TowerBaseId` property. If only towers with certain tiers, or some other condition should be saved then you should override this to change that. Do be aware that without checking the base id (`base.ShouldSave(tower)`) every tower fitting the condition you provide will be saved.
+
+Each tower has an ObjectId. You can use this to store data for each tower easily.
+
+An example using this built off of the previous example is:
+
+```cs
+using System.Collections.Generic;
+using BTD_Mod_Helper.Api;
+using Newstonsoft.Json;
+
+public class Save
+{
+    public Dictionary<string, int> MutationsCountById = [];
+}
+
+public class MyMod : BloonsTD6Mod
+{
+    // Modify this somewhere in your mod.
+    public static Dictionary<ObjectId, Save> SaveByTowerId = [];
+    public double DnaAmount = 0;
+
+    public override void OnMatchEnd()
+    {
+        SaveByTowerId.Clear();
+    }
+
+    public override void OnRestart()
+    {
+        SaveByTowerId.Clear();
+    }
+}
+
+
+public class MySaveData : ModSaveData
+{
+    public override string Save()
+    {
+        return JsonConvert.SerializeObject(MyMod.DnaAmount);
+    }
+
+    public override void Load(string data)
+    {
+        MyMod.DnaAmount = JsonConvert.DeserializeObject<double>(data);
+    }
+}
+public class MyTowerSaveData : ModTowerSaveData<MyTower>
+{
+    public override bool ShouldSave(Tower tower) => base.ShouldSave(tower) && MyMod.SaveByTowerId.ContainsKey(tower.Id);
+
+    public override string Save(Tower tower)
+    {
+        Save save = MyMod.SaveByTowerId[tower.Id]
+        return JsonConvert.SerializeObject(save);
+    }
+
+    public override void Load(string data, Tower tower)
+    {
+        Save save = JsonConvert.DeserializeObject<Save>(data);
+        MyMod.SaveByTowerId[tower.Id] = save;
+        // Handle applying the save here
+    }
+}
+```
+
+This uses an ObjectId to store the Save object we had before. When saving we get the save data using the tower's Id to search through the dictionary. When we load, we set the value with the key (the tower's Id) to the loaded save object. To make sure we don't serialize null values we override ShouldSave to also check that the dictionary containing our saves contains the key (the tower's Id)
+
+We can't directly save the dictionary here as ObjectIds are not persistent between sessions. We also cannot save references to the towers directly as those will also be invalid upon reloading the match. This is why this must use a ModTowerSaveData instead of a standard ModSaveData.
+
+An alternative to this are the `OnTowerSaved(Tower, TowerSaveDataModel)` and `OnTowerLoaded(Tower, TowerSaveDataModel)` hooks found in the BloonsTD6Mod class.

--- a/Wiki/Saving-Persistent-Data.md
+++ b/Wiki/Saving-Persistent-Data.md
@@ -7,7 +7,7 @@ Mod Helper has a system to save data that should be persistent between sessions 
 
 # [ModSaveData](/docs/BTD_Mod_Helper.Api.ModSaveData)
 
-This is the class you want to inherit from when you want to easily save and load data. It's very simple to create a ModSaveData class. All you need to do is override the `Save()` and `Load(string)` methods. All saved data are strings. You should use this when you want to save something not specific to anything. Here is a basic, generic, example:
+This is the class you want to inherit from when you want to easily save and load data. It's very simple to create a ModSaveData class. All you need to do is override the `Save()` and `Load(string)` methods. All saved data are strings. You should use this when you want to save something not specific to a tower. Here is a basic, generic, example:
 
 ```cs
 public class MySaveData : ModSaveData
@@ -30,6 +30,8 @@ Json.NET also comes with an alternative way to serialize objects to JSON, JObjec
 
 Using JSON allows you to save more complicated values without needing to make your own parsers. However, **any recurssion can cause freezing or an exception to be thrown, meaning your data won't be saved or loaded.** To prevent this from happening, you'll want a custom `Newtonsoft.Json.JsonSerializerSettings`. When serializing, you want to create a new one of these with `ReferenceLoopHandling` set to `Newtonsoft.Json.ReferenceLoopHandling.Ignore`.
 
+By default all public fields and properties are serialized. To prevent a public field/property from getting serialized give it the `Newtonsoft.Json.JsonIgnoreAttribute`. To serialize a non-public field/property give it the `Newtonsoft.Json.JsonPropertyAttribute`.
+
 Don't worry about catching exceptions during saving and loading unless you want to do something after an exception is thrown. Mod Helper will catch any thrown exceptions for you.
 
 Here's an example using `Newtonsoft.Json.JsonConvert` and a custom save data class.
@@ -41,8 +43,9 @@ using Newstonsoft.Json;
 
 public class Save
 {
-    public Dictionary<string, int> MutationsCountById = [];
-    public double DnaAmount = 0;
+    // Add whatever fields you need here
+    public Dictionary<string, int> CustomDictionary = [];
+    public double SomeNumber = 0;
 }
 
 public class MyMod : BloonsTD6Mod
@@ -76,8 +79,6 @@ public class MySaveData : ModSaveData
 }
 ```
 
-Mod Helper also provides a way to save per-tower data. 
-
 # [ModTowerSaveData](/docs/BTD_Mod_Helper.Api.ModTowerSaveData)
 
 You want to inherit from this class every time you are saving something related to towers if each tower will have it's own thing. There are two methods you must override. `Save(Il2CppAssets.Scripts.Simulation.Towers.Tower)` and `Load(string, Il2CppAssets.Scripts.Simulation.Towers.Tower)`. There is also one property you must override, `TowerBaseId`.
@@ -86,7 +87,7 @@ If you are saving this for a [ModTower](/docs/BTD_Mod_Helper.Api.Towers.ModTower
 
 You can also optionally (and probably should) override the `ShouldSave(Il2CppAssets.Scripts.Simulation.Towers.Tower)` method. This returns a bool and tells mod helper whether or not it should save the tower. By default all it does is check if the tower's tower model base id is the same as the `TowerBaseId` property. If only towers with certain tiers, or some other condition should be saved then you should override this to change that. Do be aware that without checking the base id (`base.ShouldSave(tower)`) every tower fitting the condition you provide will be saved.
 
-Each tower has an ObjectId. You can use this to store data for each tower easily.
+Each tower has an ObjectId. You can use this to store data for each tower easily using a dictionary. Make sure you remove the tower's object id from the dictionary when they are sold though. If you forget then you will have invalid data in your dictionary.
 
 An example using this built off of the previous example is:
 
@@ -95,25 +96,29 @@ using System.Collections.Generic;
 using BTD_Mod_Helper.Api;
 using Newstonsoft.Json;
 
-public class Save
+public class TowerSpecificSave
 {
-    public Dictionary<string, int> MutationsCountById = [];
+    // Add whatever poperties you need here
+    public Dictionary<string, int> TowerSpecificCustomDictionary = [];
+    public double SomeTowerSpecificValue = 0;
 }
 
 public class MyMod : BloonsTD6Mod
 {
     // Modify this somewhere in your mod.
-    public static Dictionary<ObjectId, Save> SaveByTowerId = [];
-    public double DnaAmount = 0;
+    public static Dictionary<ObjectId, TowerSpecificSave> SaveByTowerId = [];
+    public double SomeValue = 0;
 
     public override void OnMatchEnd()
     {
         SaveByTowerId.Clear();
+        SomeValue = 0;
     }
 
     public override void OnRestart()
     {
         SaveByTowerId.Clear();
+        SomeValue = 0;
     }
 }
 
@@ -122,12 +127,12 @@ public class MySaveData : ModSaveData
 {
     public override string Save()
     {
-        return JsonConvert.SerializeObject(MyMod.DnaAmount);
+        return JsonConvert.SerializeObject(MyMod.SomeValue);
     }
 
     public override void Load(string data)
     {
-        MyMod.DnaAmount = JsonConvert.DeserializeObject<double>(data);
+        MyMod.SomeValue = JsonConvert.DeserializeObject<double>(data);
     }
 }
 public class MyTowerSaveData : ModTowerSaveData<MyTower>
@@ -136,13 +141,13 @@ public class MyTowerSaveData : ModTowerSaveData<MyTower>
 
     public override string Save(Tower tower)
     {
-        Save save = MyMod.SaveByTowerId[tower.Id]
+        TowerSpecificSave save = MyMod.SaveByTowerId[tower.Id]
         return JsonConvert.SerializeObject(save);
     }
 
     public override void Load(string data, Tower tower)
     {
-        Save save = JsonConvert.DeserializeObject<Save>(data);
+        TowerSpecificSave save = JsonConvert.DeserializeObject<TowerSpecificSave>(data);
         MyMod.SaveByTowerId[tower.Id] = save;
         // Handle applying the save here
     }

--- a/Wiki/_Sidebar.md
+++ b/Wiki/_Sidebar.md
@@ -26,6 +26,7 @@
 - [Custom Byte Loaders](/wiki/Custom-Byte-Loaders)
 - [Localization](/wiki/Localization)
 - [Automated Testing](/wiki/Automated-Testing)
+- [Saving Persistent Data](/wiki/Saving-Persistent-Data)
 
 ##### **BTD Modding Info**
 - [BTD6 Internal Structure](/wiki/BTD6-Internal-Structure)


### PR DESCRIPTION
I added the `ModSaveData` and `ModTowerSaveData` classes. 

`ModSaveData` allows the person using it to save things directly to the map's metadata without worrying about it much. All they need to worry about is returning the correct string with `Save()` and parsing it correctly in `Load(string)`.

`ModTowerSaveData` allows the person using it to save things directly to a tower's metadata without needing to use the hook provided in the `BloonsTD6Mod` class. This also comes with a generic version: `ModTowerSaveData<T>`. T in this case must be a ModTower.

There is also documentation and a tutorial on using these added as well. Sorry if the documentation is not correct, it was all a little confusing to do. The tutorial explains using these classes with strings directly or using JSON instead.